### PR TITLE
Typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "lite-server",
-    "test": "echo \"Error: no test specified\" && sexit 1"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "gregory@dappuniversity.com",
   "license": "ISC",


### PR DESCRIPTION
Fixed a typo in package.json from 'sexit 1' to 'exit 1'